### PR TITLE
List Comp modified to include multiple langs for filtering

### DIFF
--- a/memsource/__init__.py
+++ b/memsource/__init__.py
@@ -200,7 +200,7 @@ class Memsource:
 
         try:
             jobs = self.handle_rest_call(url, "GET").json()["content"]
-            return jobs if not filters else [item for item in jobs if filters.items() <= item.items()]
+            return jobs if not filters else [job for job in jobs if job['targetLang'] in filters["target_langs"]]
         except Exception as exc:
             raise exc
 


### PR DESCRIPTION
Previously, the filters applied for retrieving jobs was for a single language itself. Else all jobs were being retrieved.
The modification of list comprehension now retrieves jobs based on a list of provided langs for filtering.